### PR TITLE
More explicit index concat

### DIFF
--- a/python/cudf/cudf/core/reshape.py
+++ b/python/cudf/cudf/core/reshape.py
@@ -293,6 +293,8 @@ def concat(objs, axis=0, join="outer", ignore_index=False, sort=None):
             raise TypeError(
                 "when concatenating indices you must provide ONLY indices"
             )
+        if axis == 1:
+            raise ValueError("cannot concatenate indices across axis 1")
     typs = {type(o) for o in objs}
 
     # Return for single object

--- a/python/cudf/cudf/tests/test_concat.py
+++ b/python/cudf/cudf/tests/test_concat.py
@@ -1931,3 +1931,36 @@ def test_concat_dict_incorrect_type_index(d):
         match="cannot concatenate a dictionary containing indices",
     ):
         cudf.concat(d, axis=1)
+
+
+@pytest.mark.parametrize(
+    "axis",
+    [0, 1],
+)
+@pytest.mark.parametrize(
+    "idx",
+    [
+        [cudf.Index([1, 2, 3])],
+        [cudf.Index([1, 2, 3]), cudf.Index([4, 5, 6])],
+        [
+            cudf.MultiIndex(
+                levels=[[1, 2], ["blue", "red"]],
+                codes=[[0, 0, 1, 1], [1, 0, 1, 0]],
+            )
+        ],
+        [cudf.CategoricalIndex([1, 2, 3])],
+    ],
+)
+def test_concat_index(idx, axis):
+    if axis == 1:
+        with pytest.raises(
+            ValueError, match="cannot concatenate indices across axis 1"
+        ):
+            cudf.concat(idx, axis=axis)
+    else:
+        result = cudf.concat(idx, axis=axis)
+        assert isinstance(result, cudf.Index)
+    with pytest.raises(
+        TypeError, match="only Series and DataFrame objs are valid"
+    ):
+        pd.concat([i.to_pandas() for i in idx], axis=axis)


### PR DESCRIPTION
## Description
this PR serves to continue the conversation found here https://github.com/rapidsai/cudf/pull/15623#discussion_r1586054947

note, as the test case shows, our behavior diverts from `pandas`. do we like that? if so, this PR adds some tests and a better ux

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/rapidsai/cudf/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
^ need me to create an entry in the `CHANGELOG.md`?